### PR TITLE
単語リストを取得できるようにしました

### DIFF
--- a/app/api/firebase/route.ts
+++ b/app/api/firebase/route.ts
@@ -1,4 +1,4 @@
-import { addDoc, collection, serverTimestamp } from "firebase/firestore";
+import { addDoc, collection, getDocs, serverTimestamp } from "firebase/firestore";
 import { db } from "@/firebase";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -23,5 +23,19 @@ export async function POST(req: NextRequest) {
   } catch (error) {
    console.log('error', error) ;
    return NextResponse.json({ status: 500, message: "error" });
+  }
+}
+
+export async function GET(){
+  const wordsRef = collection(db, 'words');
+  // console.log('wordsRef', wordsRef);
+
+  try {
+    const wordsSnapshot = await getDocs(wordsRef);
+    const wordLists = wordsSnapshot.docs.map((doc) => doc.data());
+    // console.log('wordLists', wordLists);
+    return NextResponse.json({ status: 200, wordLists });
+  } catch (error) {
+    console.log('error', error)
   }
 }

--- a/app/api/firebase/route.ts
+++ b/app/api/firebase/route.ts
@@ -10,8 +10,9 @@ export async function POST(req: NextRequest) {
 
     // body情報をJSON形式で取得
     const explanation = JSON.parse(body.generateExplanation);
+    
     // データを保存するためのオブジェクトを作成
-    const newWord = {explanation, createdAt: serverTimestamp()};
+    const newWord = { ...explanation, createdAt: serverTimestamp()};
 
     // Firebaseのwordsコレクションにデータを保存
     const newWordRef = collection(db, 'words');

--- a/app/api/firebase/route.ts
+++ b/app/api/firebase/route.ts
@@ -2,21 +2,18 @@ import { addDoc, collection, getDocs, serverTimestamp } from "firebase/firestore
 import { db } from "@/firebase";
 import { NextRequest, NextResponse } from "next/server";
 
+// Firebaseにデータを保存するPOST method
 export async function POST(req: NextRequest) {
   try {
+    // body情報の取得
     const body = await req.json();
-    console.log(body);
 
-    // const newWord = {
-    //   entryWords: body.generateExplanation.entryWords,
-    //   explanation: body.generateExplanation.explanation,
-    //   inJapanese: body.generateExplanation.inJapanese,
-    //   example: body.generateExplanation.example,
-    //   createdAt: serverTimestamp()
-    // };
+    // body情報をJSON形式で取得
     const explanation = JSON.parse(body.generateExplanation);
+    // データを保存するためのオブジェクトを作成
     const newWord = {explanation, createdAt: serverTimestamp()};
 
+    // Firebaseのwordsコレクションにデータを保存
     const newWordRef = collection(db, 'words');
     await addDoc(newWordRef, newWord);
     return NextResponse.json({ status: 200, message: "success" });
@@ -26,14 +23,17 @@ export async function POST(req: NextRequest) {
   }
 }
 
+// Firebaseからデータを取得するGET method
 export async function GET(){
+  // Firebaseのwordsコレクションを取得
   const wordsRef = collection(db, 'words');
-  // console.log('wordsRef', wordsRef);
 
   try {
+    // Firebaseのwordsコレクションからデータを取得
     const wordsSnapshot = await getDocs(wordsRef);
+    // Firebaseのwordsコレクションからデータを取得したものをwordListsに格納
     const wordLists = wordsSnapshot.docs.map((doc) => doc.data());
-    // console.log('wordLists', wordLists);
+
     return NextResponse.json({ status: 200, wordLists });
   } catch (error) {
     console.log('error', error)

--- a/app/api/gpt/route.ts
+++ b/app/api/gpt/route.ts
@@ -60,11 +60,26 @@ export async function POST(req: NextRequest){
 
     // GPT-3.5モデルのレスポンスを取得
     const explanation = gptResponse?.choices?.[0]?.message?.content ?? '';
+    console.log('explanation', typeof explanation);
+    
+    // explanationをJSON形式に変換
+    const explanationJson = JSON.parse(explanation);
+    console.log('explanationJson', explanationJson);
+
+    // 画像生成
+    const imageResponse = { imageUrl: '' };
+
+    // 画像生成のResponseをexplanationJsonに
+
+    const response = {
+      ...explanationJson,
+      ...imageResponse,
+    };
 
     // GPT-3.5モデルのレスポンスを返答
     return NextResponse.json({
       status: 200,
-      body: explanation,
+      body: response,
     });
   } catch (error) {
     console.error("Error generating explanation:", error);

--- a/app/api/gpt/route.ts
+++ b/app/api/gpt/route.ts
@@ -1,73 +1,7 @@
-// import { useWordsContext } from "@/src/lib/words/wordsContext";
 import { OpenAI } from "openai";
 import { NextRequest, NextResponse } from "next/server";
 
-// const prompt = `
-// ※上記単語を以下に沿って返答してください※
-
-// ##依頼内容
-// 入力された「英単語」を「##返答順序」を「##返答形式」に従い順不同で返答してください。
-// その際に「##制約条件」を必ず漏らさず守るようにしてください。
-// 英単語がエラーの場合は、「##エラー時の返答」に必ず従い、「##制約条件」は無視をしてください。
-
-// ##返答順序
-// 1. 入力された英単語をそのまま記載（entryWords）
-// 2. 英単語を英語で説明(explanation)
-// 3. 英語の説明文を日本語に訳す(explanationに対する日本語訳を行う)
-// 4. 英単語の事例の紹介(example)
-
-// 上記の順番で返答し、以下のようにjson形式で返答をしてください。
-
-// ##返答形式
-// entryWords:
-// explanation:
-// inJapanese:
-// example:
-
-// ##制約条件
-// - 英単語の綴りが間違っている場合は、日本語で指摘し、「返答内容」に沿わずに返答してください
-// - 英単語を英語で説明する際は、入力された英単語を使わずに「This word is」という形で返答
-// - 返答する文章は簡潔かつ簡単な英単語を使い、１つのセンテンスに収まるようにすること
-// - もし英単語の綴りが間違えていた場合は、以下条件に必ず漏らさず従い、返答してください
-
-// ##エラー時の返答
-// 英単語の綴りが間違っている、二文字入力されているなど条件にあわない場合は、
-// json形式は無視して、近しい英単語を返答してください。
-// `;
-
-// const englishPrompt = `
-// Please answer the above words according to the following. 
-
-// If the English word is spelled incorrectly, please ignore all of the following conditions and reply with the English word you think is correct.
-
-// ## Description of request
-// Please answer the entered "English words" according to "## Order of reply" and "## Form of reply."
-// Please make sure to follow the "## Constraints."
-// If an English word is an error, please follow the "## Response in case of error" and ignore the "## Constraints."
-
-// ## Order of reply
-// 1. Explain the English word in English (explanation)
-// 2. Translate the English explanation into Japanese (Japanese translation for explanation)
-// 3. Example of English word (example)
-
-// Please reply in the order shown above and reply only in json format as follows.
-
-// ## Response Format
-// explanation:
-// inJapanese:
-// example:
-
-// ## Constraints
-// - If an English word is misspelled, please indicate it in Japanese and reply without following the "Reply Content"
-// - When explaining an English word in English, please reply in the form "This word is" without using the typed English word
-// - Reply sentences should be concise and simple, and should fit in one sentence
-// - If an English word is misspelled, please reply with the following conditions
-
-// ## Reply in case of error
-// If an English word is misspelled or typed with two letters, etc.,
-// please reply with the closest English word, ignoring the json format.
-// `;
-
+// GPT-3.5モデルのロールのプロンプト
 const gptRole = `
 あなたは英英辞書として優秀なパートナーです。
 入力された英単語に対して、3つの返答をしてください。
@@ -88,7 +22,7 @@ const gptRole = `
   correctWord:'正しい英単語'
 }
 `
-
+// GPT-3.5モデルの指示文のプロンプト
 const gptPrompt =`
 以下の英単語を役割に従い、英語説明、英語説明の日本語訳、英単語の例文をJSON形式で返答してください。
 入力された英単語：`
@@ -99,7 +33,7 @@ const openAi = new OpenAI({
   dangerouslyAllowBrowser: true,
 });
 
-//
+//gptレスポンス取得のPOST method
 export async function POST(req: NextRequest){
   try {
     //リクエストのボディを取得
@@ -111,10 +45,12 @@ export async function POST(req: NextRequest){
       model: 'gpt-3.5-turbo',
       response_format: { type: "json_object" },
       messages: [
+        // GPT-3.5モデルのロール
         {
           role: 'system',
           content: gptRole
         },
+        // GPT-3.5モデルのユーザーメッセージ
         {
           role: 'user',
           content: gptPrompt + body.inputWord
@@ -122,14 +58,10 @@ export async function POST(req: NextRequest){
       ],
     });
 
-    //GPT-3.5モデルでレスポンスを取得
-    console.log('gptResponse', gptResponse);
-    // const explanation = gptResponse?.choices?.[0]?.message?.tool_calls?.[0]?.function?.arguments ?? '';
-    // console.log('explanation', explanation);
-    // console.log(gptResponse.choices[0].message); 
-
+    // GPT-3.5モデルのレスポンスを取得
     const explanation = gptResponse?.choices?.[0]?.message?.content ?? '';
-    console.log('explanation:', explanation);
+
+    // GPT-3.5モデルのレスポンスを返答
     return NextResponse.json({
       status: 200,
       body: explanation,

--- a/src/modules/Home/pages/Home/EnglishEntry/EnglishEntry.tsx
+++ b/src/modules/Home/pages/Home/EnglishEntry/EnglishEntry.tsx
@@ -8,7 +8,7 @@ const EnglishEntry = () => {
   
   const handleGenerate = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    // console.log('check handler')
+
     const response = await fetch('/api/gpt',{
       method: 'POST',
       headers: {
@@ -18,15 +18,13 @@ const EnglishEntry = () => {
         inputWord,
       }),
     });
-    console.log('gpt response' , response);
 
     if (!response.ok) {
       throw new Error('Network response was not ok');
     }
 
     const responseData = await response.json();
-    console.log(responseData);
-    console.log('gpt response' , responseData.body);
+
     if(responseData.status === 200){
       if(setGenerateExplanation) {
         setGenerateExplanation(responseData.body);
@@ -38,9 +36,7 @@ const EnglishEntry = () => {
   }
   
   useEffect(() => {
-    console.log('generateExplanation', generateExplanation);
     const sendFirebase = async () => {
-      console.log('generateExplanation', generateExplanation);
 
       if(!generateExplanation) {
         console.log('generateExplanation is not defined');
@@ -60,9 +56,7 @@ const EnglishEntry = () => {
       if(!firebaseResponse.ok) { 
         throw new Error('Network response was not ok');
       }
-
-      const firebaseResponseData = await firebaseResponse.json();
-      console.log(firebaseResponseData);
+      
     }
     if(generateExplanation) {
       sendFirebase();

--- a/src/modules/Home/pages/Home/EnglishEntry/EnglishEntry.tsx
+++ b/src/modules/Home/pages/Home/EnglishEntry/EnglishEntry.tsx
@@ -85,7 +85,7 @@ const EnglishEntry = () => {
           value={inputWord}
           />
           <button 
-            className='bg-neutral-600 p-1 rounded-md mt-2 text-white' 
+            className='bg-neutral-600 w-1/5 p-1 rounded-md mt-2 text-white hover:bg-neutral-700' 
             type='submit'
             >
             Generate

--- a/src/modules/Home/pages/Home/Home.tsx
+++ b/src/modules/Home/pages/Home/Home.tsx
@@ -11,7 +11,7 @@ const Home = () => {
       <div className='flex flex-col justify-center items-center'>
         <EnglishEntry />
       </div>
-      <div>
+      <div className='grid grid-cols-1 gap-4'>
         <Lists />
       </div>
     </div>

--- a/src/modules/Home/pages/Home/Lists/Lists.tsx
+++ b/src/modules/Home/pages/Home/Lists/Lists.tsx
@@ -1,6 +1,46 @@
+'use client'
+
+import { useEffect, useState } from "react"
+
+
 const Lists = () => {
+  const [wordLists, setWordLists] = useState<any[]>([]);
+  
+  const getWordLists = async () => {
+    const res = await fetch(`api/firebase`,{
+      method: 'GET'
+    })
+    const data = await res.json();
+    console.log('data', data);
+
+    if(data.status === 200) {
+      if(setWordLists) {
+        setWordLists(data.wordLists);
+      }
+    }
+          
+  }
+
+  useEffect(() => {
+    console.log('wordLists', wordLists);
+  },[wordLists])
+
+
   return (
-    <div className='text-white'>Lists</div>
+    <>
+      <p className="text-center text-white text-2xl font-bold">これまで検索した単語リスト</p>
+      <div className="grid grid-cols-4 gap-2">
+        {wordLists.map((item: any, index: number) => (
+          <div key={index} className="bg-gray-100 p-2 rounded-md">
+            <p className="text-center text-gray-800 text-3xl font-bold">{item.explanation.inputWord}</p>
+            <p className="text-gray-800 text-md">{item.explanation.explanation}</p>
+            <p className="text-gray-800 text-md">{item.explanation.inJapanese}</p>
+            <p className="text-gray-800 text-md">{item.explanation.example}</p>
+          </div>
+        ))}
+      </div>
+      <button className="w-1/5 justify-self-center bg-neutral-600 text-white p-2 rounded-md hover:bg-neutral-700" onClick={() => getWordLists()}>新規リストを取得</button>
+    </>
   )
 }
 

--- a/src/modules/Home/pages/Home/Lists/Lists.tsx
+++ b/src/modules/Home/pages/Home/Lists/Lists.tsx
@@ -11,20 +11,13 @@ const Lists = () => {
       method: 'GET'
     })
     const data = await res.json();
-    console.log('data', data);
 
     if(data.status === 200) {
       if(setWordLists) {
         setWordLists(data.wordLists);
       }
-    }
-          
+    }      
   }
-
-  useEffect(() => {
-    console.log('wordLists', wordLists);
-  },[wordLists])
-
 
   return (
     <>

--- a/src/modules/auth/pages/Login/Login.tsx
+++ b/src/modules/auth/pages/Login/Login.tsx
@@ -21,7 +21,6 @@ const Login: React.FC = () => {
   });
 
   const onSubmit: SubmitHandler<AuthProps> = async (data) => {
-    console.log(data)
     await signInWithEmailAndPassword(firebaseServices.auth, data.email, data.password)
     .then((userCredential) => {
         const user = userCredential.user;


### PR DESCRIPTION
@Yatty1 
取り急ぎ、firebaseからリストを取り出せるようにしました。
色々触りながら、引き続き足りない機能はたくさんあるという状況です。

Authの修正
・アカウント間違ってログイン、未登録→赤字で注意書きを出せるようにする
・/homeとurlに直接たたくと、ログインしてないのにhomeに移行できてしまうので解決する

homeの見栄えと機能を充実させる
・英単語登録したら出力結果のところに関しては、モーダルで表示できるようにしたい
・英単語リストに関しては、クリックすると同じようにモーダルにして、そこだけフォントをリッチにできないか
・英単語を自分だけの表示にするsortボタンを作る
・英単語を自分が登録したやつに関しては削除できるようにする
・英単語を自分が登録したやつに関しては編集できるようにする
・英単語リストのみスクロールで、英単語入力フォーム以上は固定にする

画像生成
・gptで画像生成できるステップに移行する
・画像生成された画像はfirebaseに保存されて、引っ張り出してくる？
→そうした場合、単語入力してから出力結果が得られるまでのローディング画面も欲しい
・ローディング画面には、過去登録したものがランダムに流れるようにする

テスト
・英単語をクリックすると、英単語→4択でenglishExplanationが表示される
→1つは対象英単語の英語説明で、他の3つはこれまでの登録からランダムで表示することはできないか？
↓
・結果を表示したあと、次のリマインド日程も同時に表示してあげる
・テストは対象の日付になったら、9時〜21時くらいの間で、ランダムにポップアップさせるとかできるか？
※忘却曲線
1日後、7日後、14日後、30日後

その他
テストの一覧表とか結果累積とか、どれだけ勉強したかとかサマリが表示されるのもあり
・LPページっぽいのも作れるといい（/で区切られていないトップページ）
